### PR TITLE
Fix #2 and #3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>RelicsOfCthonia</artifactId>
-    <version>Unofficial-1.0</version>
+    <version>Unofficial-1.1</version>
     <packaging>jar</packaging>
 
     <name>RelicsOfCthonia</name>

--- a/src/main/java/ne/fnfal113/relicsofcthonia/RelicsOfCthonia.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/RelicsOfCthonia.java
@@ -8,6 +8,7 @@ import ne.fnfal113.relicsofcthonia.listeners.MiningListener;
 import ne.fnfal113.relicsofcthonia.listeners.MobKillListener;
 import ne.fnfal113.relicsofcthonia.listeners.OffHandClickListener;
 import ne.fnfal113.relicsofcthonia.listeners.PiglinMainListener;
+import ne.fnfal113.relicsofcthonia.listeners.RelicPlaceBreakListener;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -53,6 +54,7 @@ public final class RelicsOfCthonia extends JavaPlugin implements SlimefunAddon {
         getServer().getPluginManager().registerEvents(new MobKillListener(), this);
         getServer().getPluginManager().registerEvents(new PiglinMainListener(), this);
         getServer().getPluginManager().registerEvents(new OffHandClickListener(), this);
+        getServer().getPluginManager().registerEvents(new RelicPlaceBreakListener(), this);
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/relicsofcthonia/droptype/DropType.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/droptype/DropType.java
@@ -13,5 +13,4 @@ public class DropType {
     );
 
 
-
 }

--- a/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MiningListener.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MiningListener.java
@@ -5,6 +5,7 @@ import ne.fnfal113.relicsofcthonia.RelicsOfCthonia;
 import ne.fnfal113.relicsofcthonia.relics.abstracts.AbstractRelic;
 import ne.fnfal113.relicsofcthonia.utils.Utils;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -29,7 +30,7 @@ public class MiningListener implements Listener {
             return;
         }
 
-        if(!event.getPlayer().getWorld().getName().equals("world_nether")){
+        if(event.getPlayer().getWorld().getEnvironment() != World.Environment.NETHER){
             return;
         }
 
@@ -48,11 +49,12 @@ public class MiningListener implements Listener {
         Utils.createAsyncTask(asyncTask -> {
            for (Map.Entry<AbstractRelic, List<Material>> entry: getWhereToDropMaterialMap().entrySet()){
                if(entry.getValue().contains(blockBrokeType)){
+                   // randomize twice since current thread random is using same seed for every block break in this loop
                    double randomOrigin = currentRandomThread.nextDouble(0.0, 60);
                    double randomNum = currentRandomThread.nextDouble(randomOrigin, 100);
 
                    if(randomNum < entry.getKey().getDropChance()) {
-                       ItemStack drop = entry.getKey().setRelicCondition();
+                       ItemStack drop = entry.getKey().setRelicCondition(true, 0);
                        Utils.createSyncTask(syncTask -> block.getWorld().dropItemNaturally(block.getLocation(), drop));
 
                        i.getAndIncrement();

--- a/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MobKillListener.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MobKillListener.java
@@ -44,7 +44,7 @@ public class MobKillListener implements Listener {
                     double randomNum = currentRandomThread.nextDouble(randomOrigin, 100);
 
                     if(randomNum < entry.getKey().getDropChance()) {
-                        ItemStack drop = entry.getKey().setRelicCondition();
+                        ItemStack drop = entry.getKey().setRelicCondition(true, 0);
                         Utils.createSyncTask(syncTask -> livingEntity.getWorld().dropItemNaturally(livingEntity.getLocation(), drop));
 
                         i.getAndIncrement();

--- a/src/main/java/ne/fnfal113/relicsofcthonia/listeners/PiglinMainListener.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/listeners/PiglinMainListener.java
@@ -132,7 +132,7 @@ public class PiglinMainListener implements Listener {
 
         // we prevent slimefun from converting barter drops if the
         // piglin has the metadata during the barter
-        if(SlimefunItem.getByItem(itemStack) instanceof StrangeNetherGoo){
+        if(SlimefunItem.getByItem(itemStack) instanceof StrangeNetherGoo && !event.isCancelled()){
             event.setCancelled(true);
         }
     }
@@ -147,8 +147,7 @@ public class PiglinMainListener implements Listener {
 
         if(event.isCancelled()){
             // if canceled call necessary callbacks
-            removeBarterMaterial(event);
-            removePiglinMetadata(piglin);
+            clearTradeData(event, piglin);
             executeTradeMessage(event, "&cFailed trade! piglin is not allowed to trade in the current location!");
 
             return;
@@ -158,7 +157,7 @@ public class PiglinMainListener implements Listener {
 
         if(!sfItem.isPresent()){
             // if not present call necessary callbacks
-            removeBarterMaterial(event);
+            clearTradeData(event, piglin);
             executeTradeMessage(event, "&cFailed trade! the barter item you gave is not a cthonian relic.");
 
             return;
@@ -202,13 +201,18 @@ public class PiglinMainListener implements Listener {
                 piglin.getWorld().playSound(piglin.getLocation(), Sound.ENTITY_PIGLIN_ADMIRING_ITEM, 1.0F, 1.0F);
 
                 if(!haveCondition){
-                    executeTradeMessage(event, "&aSuccessful trade! The relic was obtained from sf give command!");
+                    executeTradeMessage(event, "&aRelic obtained from sf give command, successful trade!");
                 }
 
             } else {
                 removeBarterMaterial(event);
             }
         } // is sf item a relic
+    }
+
+    public void clearTradeData(PiglinBarterEvent event, Piglin piglin){
+        removeBarterMaterial(event);
+        removePiglinMetadata(piglin);
     }
 
     public void removePiglinMetadata(Piglin piglin){

--- a/src/main/java/ne/fnfal113/relicsofcthonia/listeners/RelicPlaceBreakListener.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/listeners/RelicPlaceBreakListener.java
@@ -1,0 +1,117 @@
+package ne.fnfal113.relicsofcthonia.listeners;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import ne.fnfal113.relicsofcthonia.relics.abstracts.AbstractRelic;
+import ne.fnfal113.relicsofcthonia.utils.Utils;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class RelicPlaceBreakListener implements Listener {
+
+    @EventHandler
+    public void onRelicClick(PlayerInteractEvent event){
+        if(event.isCancelled()){
+            return;
+        }
+
+        if(event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getHand() == EquipmentSlot.OFF_HAND){
+            return;
+        }
+
+        if(event.getClickedBlock() == null){
+            return;
+        }
+
+        Block clickedBlock = event.getClickedBlock();
+        Player player = event.getPlayer();
+
+        Optional<SlimefunItem> relic = Optional.ofNullable(BlockStorage.check(clickedBlock));
+
+        relic.ifPresent(item -> {
+            if(item instanceof AbstractRelic){
+                event.setCancelled(true);
+
+                AbstractRelic abstractRelic = (AbstractRelic) item;
+                String value = BlockStorage.getLocationInfo(clickedBlock.getLocation(), "relic_condition");
+
+                if(!Objects.equals(BlockStorage.getLocationInfo(clickedBlock.getLocation(), "owner"), player.getUniqueId().toString())){
+                    player.sendMessage(Utils.colorTranslator("&6Hey, you are not the owner of this relic!"));
+                    return;
+                }
+
+                ItemStack itemStack = abstractRelic.setRelicCondition(false, Integer.parseInt(value));
+
+                BlockStorage.clearBlockInfo(clickedBlock);
+                clickedBlock.setType(Material.AIR);
+
+                if(player.getInventory().firstEmpty() == -1){
+                    clickedBlock.getWorld().dropItemNaturally(clickedBlock.getLocation(), itemStack.clone());
+                    return;
+                }
+
+                player.getInventory().addItem(itemStack.clone());
+            }
+        });
+
+    }
+
+    @EventHandler
+    public void onRelicPlace(BlockPlaceEvent event){
+        if(event.isCancelled()){
+            return;
+        }
+
+        Block blockPlaced = event.getBlockPlaced();
+        ItemStack itemInHand = event.getItemInHand();
+
+        Optional<SlimefunItem> relic = Optional.ofNullable(SlimefunItem.getByItem(itemInHand));
+
+        relic.ifPresent(item -> {
+            if(item instanceof AbstractRelic){
+                AbstractRelic abstractRelic = (AbstractRelic) item;
+                String value = String.valueOf(abstractRelic.getRelicCondition(itemInHand));
+
+                BlockStorage.addBlockInfo(blockPlaced, "relic_condition", value);
+                BlockStorage.addBlockInfo(blockPlaced, "owner", event.getPlayer().getUniqueId().toString());
+            }
+        });
+
+    }
+
+    @EventHandler
+    public void onRelicBreak(BlockBreakEvent event){
+        if(event.isCancelled()){
+            return;
+        }
+
+        Block blockBroken = event.getBlock();
+        Player player = event.getPlayer();
+
+        Optional<SlimefunItem> relic = Optional.ofNullable(BlockStorage.check(blockBroken));
+
+        relic.ifPresent(item -> {
+            if(item instanceof AbstractRelic){
+                event.setCancelled(true);
+                BlockStorage.clearBlockInfo(blockBroken);
+                blockBroken.setType(Material.AIR);
+
+                player.sendMessage(Utils.colorTranslator("&6You broke the relic! right click the relic instead next time to pick it up."));
+            }
+        });
+
+    }
+
+}

--- a/src/main/java/ne/fnfal113/relicsofcthonia/relics/abstracts/AbstractRelic.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/relics/abstracts/AbstractRelic.java
@@ -186,12 +186,12 @@ public abstract class AbstractRelic extends SlimefunItem implements OffHandRight
         }
     }
 
-    public ItemStack setRelicCondition(){
+    public ItemStack setRelicCondition(boolean isNaturallyDropped, int condition){
         ItemStack itemStack = this.getItem().clone();
         ItemMeta meta = itemStack.getItemMeta();
         PersistentDataContainer pdc = meta.getPersistentDataContainer();
 
-        int randomCondition = ThreadLocalRandom.current().nextInt(1,100);
+        int randomCondition = isNaturallyDropped ? ThreadLocalRandom.current().nextInt(1,100) : condition;
 
         pdc.set(Utils.createKey("relic_condition"), PersistentDataType.INTEGER, randomCondition);
         itemStack.setItemMeta(meta);


### PR DESCRIPTION
## Changes
- Relics should now be right clicked instead to pick it up or else breaking it will cause no drops 
- Fixed bugs

## Related Issues
- Resolves #2 and #3 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like for only 1.19, please report another issue here if lower versions have issues with this new update.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
