### PR TITLE
Respect disabled relics globally or per world

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>RelicsOfCthonia</artifactId>
-    <version>Unofficial-1.3</version>
+    <version>Unofficial-1.4</version>
     <packaging>jar</packaging>
 
     <name>RelicsOfCthonia</name>

--- a/src/main/java/ne/fnfal113/relicsofcthonia/config/ConfigManager.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/config/ConfigManager.java
@@ -259,7 +259,7 @@ public class ConfigManager {
             return parser.parse(new FileReader(file));
         } catch (IOException | JsonParseException | NullPointerException e) {
             e.printStackTrace();
-            return new FileReader("test");
+            return new FileReader("resource not found");
         }
     }
 

--- a/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MiningListener.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MiningListener.java
@@ -40,21 +40,29 @@ public class MiningListener implements Listener {
         // only naturally generated blocks are accepted to prevent place and break farming
         if(block.hasMetadata("placed_block")){
             block.removeMetadata("placed_block", RelicsOfCthonia.getInstance());
+
             return;
         }
 
+        World world = event.getPlayer().getWorld();
         ThreadLocalRandom currentRandomThread = ThreadLocalRandom.current();
         AtomicInteger i = new AtomicInteger(0);
 
         Utils.createAsyncTask(asyncTask -> {
            for (Map.Entry<AbstractRelic, List<Material>> entry: getWhereToDropMaterialMap().entrySet()){
+               AbstractRelic abstractRelic = entry.getKey();
+
+               if(abstractRelic.isDisabledIn(world) || abstractRelic.isDisabled()){
+                   continue;
+               }
+
                if(entry.getValue().contains(blockBrokeType)){
                    // randomize twice since current thread random is using same seed for every block break in this loop
                    double randomOrigin = currentRandomThread.nextDouble(0.0, 60);
                    double randomNum = currentRandomThread.nextDouble(randomOrigin, 100);
 
-                   if(randomNum < entry.getKey().getDropChance()) {
-                       ItemStack drop = entry.getKey().setRelicCondition(true, 0);
+                   if(randomNum < abstractRelic.getDropChance()) {
+                       ItemStack drop = abstractRelic.setRelicCondition(true, 0);
                        Utils.createSyncTask(syncTask -> block.getWorld().dropItemNaturally(block.getLocation(), drop));
 
                        i.getAndIncrement();

--- a/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MobKillListener.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MobKillListener.java
@@ -4,11 +4,14 @@ import lombok.Getter;
 import ne.fnfal113.relicsofcthonia.RelicsOfCthonia;
 import ne.fnfal113.relicsofcthonia.relics.abstracts.AbstractRelic;
 import ne.fnfal113.relicsofcthonia.utils.Utils;
+import org.bukkit.World;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
 
 import java.util.List;
 import java.util.Map;
@@ -21,30 +24,61 @@ public class MobKillListener implements Listener {
     private final Map<AbstractRelic, List<String>> whereToDropMobMap = RelicsOfCthonia.getInstance().getRelicsRegistry().getWhereToDropMobMap();
 
     @EventHandler
-    public void onMobKill(EntityDeathEvent event) {
-        LivingEntity livingEntity = event.getEntity();
-
-        if(!livingEntity.getWorld().getName().equals("world_nether")){
+    public void onMobSpawn(CreatureSpawnEvent event){
+        if(event.isCancelled()){
             return;
         }
+
+        if(event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.SPAWNER){
+            return;
+        }
+
+        if(event.getEntity().getWorld().getEnvironment() != World.Environment.NETHER){
+            return;
+        }
+
+        LivingEntity entity = event.getEntity();
+
+        entity.setMetadata("relic_spawned_mob", new FixedMetadataValue(RelicsOfCthonia.getInstance(), "spawned_mob"));
+    }
+
+    @EventHandler
+    public void onMobKill(EntityDeathEvent event) {
+        LivingEntity livingEntity = event.getEntity();
 
         if(livingEntity.getKiller() == null){
             return;
         }
 
-        String entityType = livingEntity.getType().name().toLowerCase();
+        if(livingEntity.getWorld().getEnvironment() != World.Environment.NETHER){
+            return;
+        }
 
+        if(livingEntity.hasMetadata("relic_spawned_mob")){
+            livingEntity.removeMetadata("relic_spawned_mob", RelicsOfCthonia.getInstance());
+
+            return;
+        }
+
+        String entityType = livingEntity.getType().name().toLowerCase();
+        World world = livingEntity.getWorld();
         ThreadLocalRandom currentRandomThread = ThreadLocalRandom.current();
         AtomicInteger i = new AtomicInteger(0);
 
         Utils.createAsyncTask(asyncTask -> {
             for (Map.Entry<AbstractRelic, List<String>> entry: getWhereToDropMobMap().entrySet()){
+                AbstractRelic abstractRelic = entry.getKey();
+
+                if(abstractRelic.isDisabledIn(world) || abstractRelic.isDisabled()){
+                    continue;
+                }
+
                 if(entry.getValue().contains(entityType)){
                     double randomOrigin = currentRandomThread.nextDouble(0.0, 60);
                     double randomNum = currentRandomThread.nextDouble(randomOrigin, 100);
 
-                    if(randomNum < entry.getKey().getDropChance()) {
-                        ItemStack drop = entry.getKey().setRelicCondition(true, 0);
+                    if(randomNum < abstractRelic.getDropChance()) {
+                        ItemStack drop = abstractRelic.setRelicCondition(true, 0);
                         Utils.createSyncTask(syncTask -> livingEntity.getWorld().dropItemNaturally(livingEntity.getLocation(), drop));
 
                         i.getAndIncrement();


### PR DESCRIPTION
## Changes
- Disable relic drops if disabled in a world or globally through slimefunitems.yml

## Related Issues
- Resolves #8 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
