### PR TITLE
[Fix] Block Placer placed blocks dropping relics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>RelicsOfCthonia</artifactId>
-    <version>Unofficial-1.8.1</version>
+    <version>Unofficial-1.8.2</version>
     <packaging>jar</packaging>
 
     <name>RelicsOfCthonia</name>
@@ -119,14 +119,14 @@
         <dependency>
             <groupId>com.github.baked-libs.dough</groupId>
             <artifactId>dough-updater</artifactId>
-            <version>c4231a4d1a</version>
+            <version>fcdbd45aa0</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>com.github.baked-libs.dough</groupId>
             <artifactId>dough-common</artifactId>
-            <version>c4231a4d1a</version>
+            <version>fcdbd45aa0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MiningListener.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MiningListener.java
@@ -41,7 +41,7 @@ public class MiningListener implements Listener {
         Material blockBrokeType = block.getType();
 
         // only naturally generated blocks are accepted to prevent place and break farming
-        if(block.hasMetadata("placed_block")){
+        if(block.hasMetadata("placed_block")) {
             block.removeMetadata("placed_block", RelicsOfCthonia.getInstance());
 
             return;
@@ -52,7 +52,7 @@ public class MiningListener implements Listener {
         ThreadLocalRandom currentRandomThread = ThreadLocalRandom.current();
 
         Utils.createAsyncTask(asyncTask -> {
-           Iterator<Map.Entry<AbstractRelic, List<Material>>> dropIterator =  getWhereToDropMaterialMap().entrySet().iterator(); 
+           Iterator<Map.Entry<AbstractRelic, List<Material>>> dropIterator = getWhereToDropMaterialMap().entrySet().iterator(); 
            
             while (dropIterator.hasNext()) {
                 Map.Entry<AbstractRelic, List<Material>> pair = dropIterator.next();
@@ -92,15 +92,15 @@ public class MiningListener implements Listener {
     }
 
     @EventHandler
-    public void onBlockPlace(BlockPlaceEvent event){
-        if(!event.isCancelled()){
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if(!event.isCancelled()) {
             handlePlacedBlock(event.getBlockPlaced());
         }
     }
 
     @EventHandler
     public void onBlockPlacerPlaced(BlockPlacerPlaceEvent event) {
-        if(!event.isCancelled()){
+        if(!event.isCancelled()) {
             handlePlacedBlock(event.getBlock());
         }
     }

--- a/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MiningListener.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/listeners/MiningListener.java
@@ -1,5 +1,6 @@
 package ne.fnfal113.relicsofcthonia.listeners;
 
+import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
 import lombok.Getter;
 import ne.fnfal113.relicsofcthonia.RelicsOfCthonia;
 import ne.fnfal113.relicsofcthonia.relics.abstracts.AbstractRelic;
@@ -92,15 +93,25 @@ public class MiningListener implements Listener {
 
     @EventHandler
     public void onBlockPlace(BlockPlaceEvent event){
-        if(event.isCancelled()){
-            return;
+        if(!event.isCancelled()){
+            handlePlacedBlock(event.getBlockPlaced());
         }
+    }
 
+    @EventHandler
+    public void onBlockPlacerPlaced(BlockPlacerPlaceEvent event) {
+        if(!event.isCancelled()){
+            handlePlacedBlock(event.getBlock());
+        }
+    }
+
+
+    public void handlePlacedBlock(Block block) {
         /*
          * Prevent players from block place farming any relics
          * This will be detected above in the block break event
          */
-        event.getBlockPlaced().setMetadata("placed_block", new FixedMetadataValue(RelicsOfCthonia.getInstance(), "placed"));
+        block.setMetadata("placed_block", new FixedMetadataValue(RelicsOfCthonia.getInstance(), "placed"));
     }
 
 }

--- a/src/main/java/ne/fnfal113/relicsofcthonia/listeners/RelicPlaceBreakListener.java
+++ b/src/main/java/ne/fnfal113/relicsofcthonia/listeners/RelicPlaceBreakListener.java
@@ -79,7 +79,7 @@ public class RelicPlaceBreakListener implements Listener {
         Optional<SlimefunItem> relic = Optional.ofNullable(SlimefunItem.getByItem(itemInHand));
 
         relic.ifPresent(item -> {
-            if(item instanceof AbstractRelic){
+            if(item instanceof AbstractRelic) {
                 Utils.sendRelicMessage("You placed a relic, it will not drop anything once broken!", event.getPlayer());
             }
         });
@@ -87,7 +87,7 @@ public class RelicPlaceBreakListener implements Listener {
     }
 
     @EventHandler
-    public void onRelicBreak(BlockBreakEvent event){
+    public void onRelicBreak(BlockBreakEvent event) {
         if(event.isCancelled()){
             return;
         }
@@ -97,7 +97,7 @@ public class RelicPlaceBreakListener implements Listener {
         Optional<SlimefunItem> relic = Optional.ofNullable(BlockStorage.check(blockBroken));
 
         relic.ifPresent(item -> {
-            if(item instanceof AbstractRelic){
+            if(item instanceof AbstractRelic) {
                 event.setCancelled(true);
 
                 BlockStorage.clearBlockInfo(blockBroken);


### PR DESCRIPTION
## Changes
- Moved the body of `MiningListener#onBlockPlace` to a new method `MiningListener#handlePlacedBlock`
 - Updated `MiningListener#onBlockPlace` to use that method
- Added another `MiningListener#onBlockPlacerPlace` that listens to `BlockPlacerPlaceEvent` it calls `MiningListener#handlePlacedBlock`

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
